### PR TITLE
fix(nav): mobile drawer covers viewport, locks scroll, animates to X

### DIFF
--- a/_includes/body/sections/navbar.html
+++ b/_includes/body/sections/navbar.html
@@ -4,8 +4,8 @@
 	<nav class="sk-nav" aria-label="Primary">
 		<div class="sk-nav__inner">
 			<a class="sk-nav__brand" href="{{ site.url }}/">{{ site.brand | default: site.name }}</a>
-			<button class="sk-nav__toggle" type="button" aria-expanded="false" aria-controls="sk-nav-list" aria-label="Toggle menu">
-				<svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path d="M2 5h14M2 9h14M2 13h14"/></svg>
+			<button class="sk-nav__toggle" type="button" aria-expanded="false" aria-controls="sk-nav-list" aria-label="Open menu">
+				<span class="sk-nav__toggle-icon" aria-hidden="true"></span>
 			</button>
 			<ul class="sk-nav__list" id="sk-nav-list">
 				<li><a href="{{ site.url }}/archive.html">Archive</a></li>
@@ -29,11 +29,52 @@
 			while (nav && !nav.classList.contains('sk-nav')) nav = nav.previousElementSibling;
 			if (!nav) return;
 			var toggle = nav.querySelector('.sk-nav__toggle');
-			if (!toggle) return;
+			var list = nav.querySelector('.sk-nav__list');
+			if (!toggle || !list) return;
+
+			var MOBILE = '(max-width: 720px)';
+			var isMobile = function(){ return window.matchMedia(MOBILE).matches; };
+
+			var setOpen = function(open){
+				nav.setAttribute('data-open', open ? 'true' : 'false');
+				toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+				toggle.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+				document.documentElement.classList.toggle('sk-nav-open', open && isMobile());
+			};
+
 			toggle.addEventListener('click', function(){
-				var open = nav.getAttribute('data-open') === 'true';
-				nav.setAttribute('data-open', open ? 'false' : 'true');
-				toggle.setAttribute('aria-expanded', open ? 'false' : 'true');
+				setOpen(nav.getAttribute('data-open') !== 'true');
+			});
+
+			list.addEventListener('click', function(e){
+				var link = e.target.closest('a');
+				if (link) setOpen(false);
+			});
+
+			document.addEventListener('keydown', function(e){
+				if (e.key !== 'Escape') return;
+				if (nav.getAttribute('data-open') !== 'true') return;
+				setOpen(false);
+				toggle.focus();
+			});
+
+			list.addEventListener('keydown', function(e){
+				if (e.key !== 'Tab') return;
+				if (nav.getAttribute('data-open') !== 'true' || !isMobile()) return;
+				var focusables = [toggle].concat(Array.prototype.slice.call(list.querySelectorAll('a')));
+				var first = focusables[0];
+				var last = focusables[focusables.length - 1];
+				if (e.shiftKey && document.activeElement === first) {
+					e.preventDefault();
+					last.focus();
+				} else if (!e.shiftKey && document.activeElement === last) {
+					e.preventDefault();
+					first.focus();
+				}
+			});
+
+			window.addEventListener('resize', function(){
+				if (!isMobile() && nav.getAttribute('data-open') === 'true') setOpen(false);
 			});
 		})();
 	</script>

--- a/css/gh-pages-blog.css
+++ b/css/gh-pages-blog.css
@@ -86,44 +86,119 @@
 /* Mobile menu toggle */
 .sk-nav__toggle {
   display: none;
-  width: 32px;
-  height: 32px;
+  position: relative;
+  width: 44px;
+  height: 44px;
   background: transparent;
   border: 0;
   color: #ffffff;
   padding: 0;
   align-items: center;
   justify-content: center;
+  z-index: 2;
 }
 
-.sk-nav__toggle svg {
-  width: 18px;
-  height: 18px;
+.sk-nav__toggle-icon,
+.sk-nav__toggle-icon::before,
+.sk-nav__toggle-icon::after {
+  content: '';
+  display: block;
+  position: absolute;
+  left: 50%;
+  width: 20px;
+  height: 1.5px;
+  background: #ffffff;
+  border-radius: 1px;
+  transform: translateX(-50%);
+  transition: transform 220ms ease, top 220ms ease, background-color 160ms ease;
+}
+.sk-nav__toggle-icon { top: 50%; margin-top: -0.75px; }
+.sk-nav__toggle-icon::before { top: -6px; }
+.sk-nav__toggle-icon::after { top: 6px; }
+
+.sk-nav[data-open='true'] .sk-nav__toggle-icon {
+  background: transparent;
+}
+.sk-nav[data-open='true'] .sk-nav__toggle-icon::before {
+  top: 0;
+  transform: translateX(-50%) rotate(45deg);
+}
+.sk-nav[data-open='true'] .sk-nav__toggle-icon::after {
+  top: 0;
+  transform: translateX(-50%) rotate(-45deg);
+}
+
+/* Lock body scroll while the drawer is open (toggled from JS) */
+html.sk-nav-open,
+html.sk-nav-open body {
+  overflow: hidden;
+  touch-action: none;
 }
 
 @media (max-width: 720px) {
   .sk-nav__toggle { display: inline-flex; }
+
   .sk-nav__list {
     position: fixed;
-    inset: var(--sk-nav-height) 0 0 0;
+    top: var(--sk-nav-height);
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
     flex-direction: column;
     align-items: stretch;
+    justify-content: flex-start;
     gap: 0;
-    padding: 24px 22px;
-    background: rgba(0, 0, 0, 0.94);
-    backdrop-filter: saturate(180%) blur(20px);
-    -webkit-backdrop-filter: saturate(180%) blur(20px);
-    transform: translateY(-100%);
-    transition: transform 220ms ease;
+    margin: 0;
+    padding: 8px 0 max(24px, env(safe-area-inset-bottom));
+    background: #000000;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: opacity 220ms ease, transform 220ms ease, visibility 0s linear 220ms;
   }
   .sk-nav[data-open='true'] .sk-nav__list {
+    opacity: 1;
+    visibility: visible;
     transform: translateY(0);
+    transition: opacity 220ms ease, transform 220ms ease, visibility 0s linear 0s;
   }
-  .sk-nav__list a {
-    font-size: 20px;
-    padding: 14px 8px;
-    border-radius: 0;
+
+  .sk-nav__list li {
+    width: 100%;
     border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .sk-nav__list li:last-child { border-bottom: 0; }
+
+  .sk-nav__list a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 56px;
+    padding: 16px 22px;
+    font-size: 22px;
+    font-weight: 400;
+    letter-spacing: -0.016em;
+    color: #ffffff;
+    text-align: center;
+    border-radius: 0;
+    border-bottom: 0;
+  }
+  .sk-nav__list a:hover,
+  .sk-nav__list a:focus-visible {
+    background: rgba(255, 255, 255, 0.06);
+  }
+  .sk-nav__external {
+    justify-content: center;
+    gap: 8px;
+  }
+  .sk-nav__ext-icon {
+    width: 12px;
+    height: 12px;
   }
 }
 


### PR DESCRIPTION
Old overlay used inset shorthand with a translucent black and no scroll
lock, leaving page content visibly bleeding through and the menu
half-rendered on mobile. Rewrite the drawer to be a solid full-viewport
panel with centered full-width rows, bigger 56px tap targets, and a
safe-area-aware bottom padding. Hamburger morphs to an X when open.
Body scroll locks via an html.sk-nav-open class; Escape and tapping a
link close the drawer; Tab cycles focus between toggle and links; the
drawer auto-closes if the viewport grows past the mobile breakpoint.