### PR TITLE
chore: point Boxd Card post links at boxd-card.com

### DIFF
--- a/_posts/2026-03-25-dont-screenshot-your-letterboxd-last-four-watched-anymore.md
+++ b/_posts/2026-03-25-dont-screenshot-your-letterboxd-last-four-watched-anymore.md
@@ -16,7 +16,7 @@ On Threads or Bluesky, I'll look for a post from the official Letterboxd account
 
 ## Introducing boxd-card (beta)
 
-[![Boxd Card logo](/img/2026-03-25-boxd-card-favicon.svg)](https://boxd-card.michaellamb.dev)
+[![Boxd Card logo](/img/2026-03-25-boxd-card-favicon.svg)](https://boxd-card.com)
 
 Boxd Card is web browser extension that generates a shareable image card from your Letterboxd profile. A web app version also exists but faces some technical limitations, so for the full-featured experience I recommend taking the 4 steps required to install the browser extension. 
 
@@ -44,7 +44,7 @@ The extension reads film metadata and poster images directly from the Letterboxd
 
 The web browser extension works with any Chromium-based browser with developer mode enabled.
 
-### Web app (beta boxd-card.michaellamb.dev/app/)
+### Web app (beta boxd-card.com/app/)
 
 The web app exists but has some technical limitations that prevent it from being as feature-rich as the browser extension. It uses a Cloudflare Worker to proxy requests to Letterboxd, which unfortunately blocks some requests using WAF rules. Last Four Watched and Favorites work fine, but other card types may not work as expected. This is because the web app cannot directly access the Letterboxd page DOM like the browser extension can, and the proxying adds an extra layer of complexity. WAF rules block known browser automation tools, making it difficult to scrape data directly from the page. An API integration with Letterboxd could assist with this, but I have not submitted a request for credentials.
 

--- a/_posts/2026-04-07-reflecting-on-claude-code-creating-boxd-card.md
+++ b/_posts/2026-04-07-reflecting-on-claude-code-creating-boxd-card.md
@@ -12,7 +12,7 @@ tags:
 
 ## Introduction
 
-[Boxd Card](https://boxd-card.michaellamb.dev) is a tool I built with [Claude Code](https://claude.ai/code) that generates shareable PNG image cards from Letterboxd profiles. It started as a Chrome extension and grew into a dual-target project: the same codebase produces both a Chrome MV3 extension and a standalone web app at [boxd-card.michaellamb.dev/app/](https://boxd-card.michaellamb.dev/app/).
+[Boxd Card](https://boxd-card.com) is a tool I built with [Claude Code](https://claude.ai/code) that generates shareable PNG image cards from Letterboxd profiles. It started as a Chrome extension and grew into a dual-target project: the same codebase produces both a Chrome MV3 extension and a standalone web app at [boxd-card.com/app/](https://boxd-card.com/app/).
 
 This post is a reflection on what Claude Code built and the technical decisions it made along the way — particularly around managing two build targets from one codebase, the versioning and release pipeline, and the automation that keeps it all working smoothly.
 

--- a/_posts/2026-04-14-install-boxd-card-from-the-chrome-web-store.md
+++ b/_posts/2026-04-14-install-boxd-card-from-the-chrome-web-store.md
@@ -11,7 +11,7 @@ tags:
 
 ## One-click install, finally
 
-[Boxd Card](https://boxd-card.michaellamb.dev) is now available on the Chrome Web Store:
+[Boxd Card](https://boxd-card.com) is now available on the Chrome Web Store:
 
 👉 [**Install Boxd Card**](https://chromewebstore.google.com/detail/boxd-card/kcholfdhfcojahebmneeeikelffkokdj?authuser=0&hl=en)
 


### PR DESCRIPTION
Boxd Card migrated from the beta domain `boxd-card.michaellamb.dev` to the production domain `boxd-card.com`. This updates the reader-facing CTA links in the three pre-migration posts so readers land on the canonical domain (rather than relying on the 301).

**Updated:**
- `2026-03-25-dont-screenshot…` — logo link + web-app heading
- `2026-04-07-reflecting-on-claude-code…` — intro CTA links
- `2026-04-14-install-boxd-card-from-the-chrome-web-store` — intro link

**Deliberately left unchanged:**
- `2026-05-16-boxd-card-migration` — the post narrates the `boxd-card.michaellamb.dev` → `boxd-card.com` move; its old-domain references are the point.
- One sentence in the 2026-04-07 post describing the former GitHub Pages hosting at the beta domain — accurate historical detail (post-migration the apex is Cloudflare Pages, so a bare domain swap would make it wrong).

URL-only edits; existing SEO images unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)