### PR TITLE
blog: audit and reconcile post categories and tags

### DIFF
--- a/_posts/2021-03-25-cluster-computing.md
+++ b/_posts/2021-03-25-cluster-computing.md
@@ -3,6 +3,7 @@ layout: post
 title: What I'm working on right now
 category: infrastructure
 tags:
+- homelab
 - raspberry-pi
 - cluster
 - kubernetes

--- a/_posts/2021-03-26-cluster-update.md
+++ b/_posts/2021-03-26-cluster-update.md
@@ -3,6 +3,7 @@ layout: post
 title: Pi Cluster Update
 category: infrastructure
 tags:
+- homelab
 - raspberry-pi
 - cluster
 - tutorial

--- a/_posts/2021-03-27-working-config.md
+++ b/_posts/2021-03-27-working-config.md
@@ -3,6 +3,7 @@ layout: post
 title: Workspace Configuration
 category: infrastructure
 tags:
+- homelab
 - raspberry-pi
 - cluster
 - tutorial

--- a/_posts/2021-03-28-ansible-installation.md
+++ b/_posts/2021-03-28-ansible-installation.md
@@ -3,6 +3,7 @@ layout: post
 title: Ansible Installation
 category: infrastructure
 tags:
+- homelab
 - ansible
 - raspberry-pi
 - cluster

--- a/_posts/2022-01-20-k3s-installation.md
+++ b/_posts/2022-01-20-k3s-installation.md
@@ -4,6 +4,7 @@ title : k3s Installation
 image : "/seo/2022-01-20.png"
 category: infrastructure
 tags:
+- homelab
 - kubernetes
 - k3s
 - raspberry-pi

--- a/_posts/2022-02-06-containers.md
+++ b/_posts/2022-02-06-containers.md
@@ -4,6 +4,7 @@ title : Containers on k3s
 image : "/seo/2022-02-06.png"
 category : infrastructure
 tags:
+- homelab
 
 - kubernetes
 - raspberry-pi

--- a/_posts/2022-02-16-go-back-n-protocol.md
+++ b/_posts/2022-02-16-go-back-n-protocol.md
@@ -2,7 +2,7 @@
 layout : post
 title : Go-Back-N Protocol
 image : "/seo/2022-02-16.png"
-category : projects
+category : infrastructure
 tags: 
 
 - feature

--- a/_posts/2022-03-07-introducing-status_michaellamb_dev.md
+++ b/_posts/2022-03-07-introducing-status_michaellamb_dev.md
@@ -4,6 +4,7 @@ title : Introducing status.michaellamb.dev
 image : "/seo/2022-03-07.png"
 category : infrastructure
 tags:
+- homelab
 
 - docker
 - raspberry-pi	

--- a/_posts/2022-03-20-the-fuck.md
+++ b/_posts/2022-03-20-the-fuck.md
@@ -2,7 +2,7 @@
 layout: post
 title: Featured Project - the fuck
 image : "/seo/2022-03-20.png"
-category: projects
+category: software
 tags: 
 - feature
 - review

--- a/_posts/2023-01-18-chatgpt-three-questions.md
+++ b/_posts/2023-01-18-chatgpt-three-questions.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Three Questions for ChatGPT
-category: development
+category: machine-intelligence
 tags:
 - ai
 - chatgpt

--- a/_posts/2023-05-24-dash-dot.md
+++ b/_posts/2023-05-24-dash-dot.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Featured Project - dash. - a glassmorphic dashboard
-category: projects
+category: software
 tags:
 - feature
 - dashboard

--- a/_posts/2023-07-12-jxnfilmclub.md
+++ b/_posts/2023-07-12-jxnfilmclub.md
@@ -3,6 +3,7 @@ layout: post
 title: JXN Film Club - PODCAST REVIVAL
 category: community
 tags:
+- jxnfilmclub
 - podcast
 - movies
 - local

--- a/_posts/2023-12-29-container-relocation.md
+++ b/_posts/2023-12-29-container-relocation.md
@@ -4,6 +4,7 @@ title: Relocating a Docker Container
 category: infrastructure
 image: "/seo/2023-12-29.png"
 tags:
+- homelab
 - guide
 - docker
 - raspberry-pi

--- a/_posts/2024-03-14-new-macbook.md
+++ b/_posts/2024-03-14-new-macbook.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: New M3 MacBook Air && Ollama
-category: personal
+category: machine-intelligence
 tags:
 - ai
 - machine-learning

--- a/_posts/2025-01-09-my-experience.md
+++ b/_posts/2025-01-09-my-experience.md
@@ -2,8 +2,9 @@
 layout: post
 title: "My experience with the Intelligence we have given machines"
 date: 2025-01-09
-category: development
+category: machine-intelligence
 tags:
+- ai
 - machine-intelligence
 - personal
 image: "/seo/2025-01-09.png"

--- a/_posts/2025-01-28-sherlock.md
+++ b/_posts/2025-01-28-sherlock.md
@@ -3,7 +3,7 @@ layout: post
 title: "Sherlock Project"
 date: 2025-01-28
 image: "/seo/2025-01-28.png"
-category: projects
+category: software
 tags: 
 - feature
 - review

--- a/_posts/2025-02-21-letterboxd-viewer.md
+++ b/_posts/2025-02-21-letterboxd-viewer.md
@@ -2,8 +2,9 @@
 layout: post
 title: "I built a custom Letterboxd diary viewer"
 date: 2025-02-21 
-category: projects
+category: software
 tags:
+- letterboxd
 - project
 - javascript
 - api

--- a/_posts/2025-06-13-lazy-sme.md
+++ b/_posts/2025-06-13-lazy-sme.md
@@ -2,8 +2,9 @@
 layout: post
 title: "The Tale of the Lazy SME"
 date: 2025-06-13
-category: reflections
+category: machine-intelligence
 tags:
+- ai
 - opinion
 - machine-intelligence
 image: "/seo/2025-06-13.png"

--- a/_posts/2025-07-09-machine-intelligence.md
+++ b/_posts/2025-07-09-machine-intelligence.md
@@ -4,8 +4,9 @@ title: "All of this has happened before"
 date: 2025-07-09
 image: "/seo/2025-07-09.png"
 published: true
-category: reflections
+category: machine-intelligence
 tags:
+- ai
 - opinion
 - machine-intelligence
 

--- a/_posts/2025-09-16-newsletters.md
+++ b/_posts/2025-09-16-newsletters.md
@@ -11,7 +11,7 @@ tags:
 - email
 - blogging
 - communication
-- indie-web
+- indieweb
 image: "/seo/2025-09-16.png"
 published: true
 ---

--- a/_posts/2025-09-18-memory.md
+++ b/_posts/2025-09-18-memory.md
@@ -3,7 +3,7 @@
 layout: post
 title: "We should listen to more music with people the same way we watch movies"
 date: 2025-09-18
-category: personal
+category: reflections
 image: "/seo/2025-09-18.png"
 tags:
 

--- a/_posts/2025-09-19-symphony.md
+++ b/_posts/2025-09-19-symphony.md
@@ -3,7 +3,7 @@
 layout: post
 title: "Jackson Film Club goes to the symphony"
 date: 2025-09-19
-category: personal
+category: community
 image: "/seo/2025-09-19.png"
 tags:
 

--- a/_posts/2025-09-30-comfort-movies.md
+++ b/_posts/2025-09-30-comfort-movies.md
@@ -1,7 +1,7 @@
 ---
 title: Why any movie can be a comfort movie
 image: seo/2025-09-30.png
-category: personal
+category: reflections
 date: '2025-09-30 00:00:00'
 tags:
 - movies

--- a/_posts/2025-10-25-unsplash.md
+++ b/_posts/2025-10-25-unsplash.md
@@ -2,7 +2,7 @@
 title: Unsplash Wallpapers app bloats macOS System Data
 layout: post
 date: 2025-10-25
-category: troubleshooting
+category: personal
 image: "/seo/2025-10-25.png"
 tags:
 

--- a/_posts/2026-03-25-dont-screenshot-your-letterboxd-last-four-watched-anymore.md
+++ b/_posts/2026-03-25-dont-screenshot-your-letterboxd-last-four-watched-anymore.md
@@ -4,6 +4,7 @@ title: "Don't screenshot your Letterboxd Last Four Watched anymore"
 image: "/seo/2026-03-25.png"
 category: software
 tags:
+- movies
 - letterboxd
 - chrome-extension
 - react

--- a/_posts/2026-04-07-reflecting-on-claude-code-creating-boxd-card.md
+++ b/_posts/2026-04-07-reflecting-on-claude-code-creating-boxd-card.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Reflecting on Claude Code creating Boxd Card"
 date: 2026-04-07
-category: software
+category: machine-intelligence
 image: "/seo/2026-04-07.png"
 tags:
 - claude-code

--- a/_posts/2026-04-14-custom-letterboxd-stats-viewer.md
+++ b/_posts/2026-04-14-custom-letterboxd-stats-viewer.md
@@ -4,6 +4,7 @@ title: "Custom Letterboxd Stats Viewer"
 image: "/seo/2026-04-14-custom-letterboxd-stats-viewer.png"
 category: software
 tags:
+- movies
 - letterboxd
 - data-pipeline
 - github-actions

--- a/_posts/2026-04-14-install-boxd-card-from-the-chrome-web-store.md
+++ b/_posts/2026-04-14-install-boxd-card-from-the-chrome-web-store.md
@@ -4,6 +4,7 @@ title: "Install Boxd Card from the Chrome Web Store"
 image: "/seo/2026-04-14.png"
 category: software
 tags:
+- movies
 - letterboxd
 - chrome-extension
 - beta

--- a/_posts/2026-04-24-the-regex-library-became-the-few-shot.md
+++ b/_posts/2026-04-24-the-regex-library-became-the-few-shot.md
@@ -2,7 +2,7 @@
 layout: post
 title: "The regex library became the few-shot"
 date: 2026-04-24
-category: software
+category: machine-intelligence
 image: "/seo/2026-04-24-the-regex-library-became-the-few-shot.png"
 tags:
 - llm

--- a/_posts/2026-04-27-my-week-with-claude-april-20-april-24.md
+++ b/_posts/2026-04-27-my-week-with-claude-april-20-april-24.md
@@ -2,7 +2,7 @@
 layout: post
 title: "My week with Claude -- April 20 - April 24"
 date: 2026-04-27
-category: software
+category: machine-intelligence
 image: "/seo/2026-04-27-my-week-with-claude-april-20-april-24.png"
 tags:
 - claude-code

--- a/_posts/2026-04-30-re-introducing-status-michaellamb-dev.md
+++ b/_posts/2026-04-30-re-introducing-status-michaellamb-dev.md
@@ -5,6 +5,8 @@ date: 2026-04-30
 category: infrastructure
 image: "/seo/2026-04-30-re-introducing-status-michaellamb-dev.png"
 tags:
+- claude-code
+- homelab
 - cloudflare
 - raspberry-pi
 - observability

--- a/_posts/2026-05-06-cluster-led-id-systemd.md
+++ b/_posts/2026-05-06-cluster-led-id-systemd.md
@@ -5,6 +5,7 @@ date: 2026-05-06
 category: infrastructure
 image: "/seo/2026-05-06-cluster-led-id-systemd.png"
 tags:
+- homelab
 - raspberry-pi
 - cluster
 - automation

--- a/_posts/2026-05-16-boxd-card-migration.md
+++ b/_posts/2026-05-16-boxd-card-migration.md
@@ -4,6 +4,8 @@ title: Migrating boxd-card
 image: "/seo/2026-05-16-boxd-card-migration.png"
 category: software
 tags:
+- claude-code
+- movies
 - boxd-card
 - chrome-extension
 - letterboxd

--- a/_posts/2026-06-01-adapting-the-now-convention.md
+++ b/_posts/2026-06-01-adapting-the-now-convention.md
@@ -5,6 +5,7 @@ date: 2026-06-01
 category: personal
 image: "/seo/2026-06-01-adapting-the-now-convention.png"
 tags:
+- claude-code
 - now-page
 - indieweb
 - letterboxd

--- a/_posts/2026-06-19-boxd-card-now-lives-at-boxd-card-com.md
+++ b/_posts/2026-06-19-boxd-card-now-lives-at-boxd-card-com.md
@@ -4,6 +4,7 @@ title: "Boxd Card now lives at boxd-card.com"
 image: "/seo/2026-06-19.png"
 category: software
 tags:
+- movies
 - letterboxd
 - chrome-extension
 - boxd-card

--- a/_posts/2026-06-24-five-deploys-before-last-call-a-build-log-for-taproom-trivias-leaderboard.md
+++ b/_posts/2026-06-24-five-deploys-before-last-call-a-build-log-for-taproom-trivias-leaderboard.md
@@ -2,10 +2,11 @@
 layout: post
 title: "Five deploys before last call: a build log for Taproom Trivia's leaderboard"
 date: 2026-06-24
-category: development
+category: software
 subtitle: "Published at 12:30 AM — three hours after trivia wrapped."
 image: "/seo/2026-06-24-five-deploys-before-last-call-a-build-log-for-taproom-trivias-leaderboard.png"
 tags:
+- trivia
 - claude-code
 - react
 - cloudflare

--- a/_posts/2026-07-07-anatomy-of-a-trivia-deck-part-1-no-backend.md
+++ b/_posts/2026-07-07-anatomy-of-a-trivia-deck-part-1-no-backend.md
@@ -2,10 +2,11 @@
 layout: post
 title: "Anatomy of a trivia deck, part 1: a presentation app with no backend"
 date: 2026-07-07 09:00:00 -0500
-category: development
+category: software
 subtitle: "First in a five-part series on the architecture of the pub-trivia scaffold."
 image: "/seo/2026-07-07-anatomy-of-a-trivia-deck-part-1-no-backend.png"
 tags:
+- claude-code
 - react
 - javascript
 - architecture

--- a/_posts/2026-07-07-anatomy-of-a-trivia-deck-part-2-deck-stage.md
+++ b/_posts/2026-07-07-anatomy-of-a-trivia-deck-part-2-deck-stage.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Anatomy of a trivia deck, part 2: a web component at the center of a React app"
 date: 2026-07-08 23:45:00 -0500
-category: development
+category: software
 subtitle: "Part 2 of 5 — the <deck-stage> element: scaling, navigation, and print in vanilla JS."
 image: "/seo/2026-07-07-anatomy-of-a-trivia-deck-part-2-deck-stage.png"
 tags:


### PR DESCRIPTION
Category migrations (URL-safe; category is not part of the permalink):
- Consolidate scattered AI posts into machine-intelligence (2 -> 10)
- Move 2026 build-log posts from development -> software
- Retire legacy "projects" bucket into software (+ one to infrastructure)
- Fold singleton "troubleshooting" into personal
- Resolve personal/reflections/community boundary cases

Tag fixes:
- Add confirmed-missing tags: letterboxd (letterboxd-viewer), jxnfilmclub (namesake post), trivia (taproom build-log), claude-code (4 posts that reference it in-body)
- Normalize indie-web -> indieweb
- Backfill homelab across the cluster/homelab infra series
- Backfill ai umbrella on AI-centric posts
- Add movies cross-tag to letterboxd/boxd-card posts

projects and troubleshooting categories are now empty and drop off the categories page. All 81 posts validated against Ruby YAML.